### PR TITLE
Chat User Images Adjustments

### DIFF
--- a/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/ChatAdapter.kt
@@ -352,9 +352,16 @@ class ChatAdapter(
                 if (position > 0) {
                     try {
                         val nextItem = getItem(position + 1).fromUserId
+                        val previousItem = getItem(position - 1).fromUserId
 
                         val currentItem = it.fromUserId
                         Timber.d("Items : $nextItem, $currentItem ${nextItem == currentItem}")
+
+                        if (previousItem == currentItem) {
+                            holder.binding.cvUserImage.visibility = View.INVISIBLE
+                        } else {
+                            holder.binding.cvUserImage.visibility = View.VISIBLE
+                        }
 
                         if (nextItem == currentItem) {
                             holder.binding.tvUsername.visibility = View.GONE
@@ -364,9 +371,11 @@ class ChatAdapter(
                     } catch (ex: IndexOutOfBoundsException) {
                         Tools.checkError(ex)
                         holder.binding.tvUsername.visibility = View.VISIBLE
+                        holder.binding.cvUserImage.visibility = View.VISIBLE
                     }
                 } else {
                     holder.binding.tvUsername.visibility = View.VISIBLE
+                    holder.binding.cvUserImage.visibility = View.VISIBLE
                 }
             }
         }

--- a/app/src/main/res/layout/item_message_other.xml
+++ b/app/src/main/res/layout/item_message_other.xml
@@ -28,7 +28,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toEndOf="@+id/cardView2"
+            app:layout_constraintStart_toEndOf="@+id/cv_user_image"
             app:layout_constraintTop_toBottomOf="@+id/tv_username">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -223,14 +223,13 @@
             app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.cardview.widget.CardView
-            android:id="@+id/cardView2"
+            android:id="@+id/cv_user_image"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/sixteen_dp_margin"
             app:cardCornerRadius="@dimen/ten_dp_margin"
             app:layout_constraintBottom_toBottomOf="@+id/cl_container"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/cl_container">
+            app:layout_constraintStart_toStartOf="parent">
 
             <ImageView
                 android:id="@+id/iv_user_image"


### PR DESCRIPTION
Moved user image to the bottom of the chat bubble and implemented logic to display the image only nexto to the bubble in the last message in a row.

![1666783468285_Screenshot_20221026-132408_Spika3](https://user-images.githubusercontent.com/50554253/198014663-5ca46bb6-842e-4026-b402-4b7347e6ccf5.jpg)
