### PR TITLE
ExoPlayer Single Instance

### DIFF
--- a/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/MediaFragment.kt
+++ b/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/MediaFragment.kt
@@ -129,6 +129,9 @@ class MediaFragment : Fragment() {
             playWhenReady = exoPlayer.playWhenReady
             exoPlayer.removeListener(playbackStateListener)
             exoPlayer.release()
+
+            // Since ExoPlayer is released, we need to reset the singleton instance to null. Instead
+            // we won't be able to use ExoPlayer instance anymore since it is released.
             MediaPlayer.resetPlayer()
         }
     }

--- a/app/src/main/java/com/clover/studio/exampleapp/utils/helpers/MediaPlayer.kt
+++ b/app/src/main/java/com/clover/studio/exampleapp/utils/helpers/MediaPlayer.kt
@@ -4,6 +4,11 @@ import android.content.Context
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 
+/**
+ * Creates a single instance of ExoPlayer which can be used throughout the app.
+ *
+ * Don't forget to call resetPlayer() when ExoPlayer is released.
+ */
 object MediaPlayer {
     private var instance: ExoPlayer? = null
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed issue with ExoPlayer creating multiple instances in MediaFragment and not stopping them. Created a Singleton class which will handle single ExoPlayer instance. Handled releasing the player and resetting the instance.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing, checking video player, orientation changes, fragment changes, seekbar and controller. 

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 12

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
