### PR TITLE
Zoom Fullscreen

### DIFF
--- a/app/src/main/res/layout/fragment_media.xml
+++ b/app/src/main/res/layout/fragment_media.xml
@@ -98,8 +98,8 @@
 
         <com.ortiz.touchview.TouchImageView
             android:id="@+id/iv_full_image"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixed issue with image not going full screen when zooming in. It was caused by wrap content in the image view. Updated to match_parent.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 12

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

![1669379548273_Screenshot_20221125_133218_Spika3](https://user-images.githubusercontent.com/50554253/203987152-06b4d608-0e04-4ef1-8cb7-a46ebf0a0251.jpg)
![1669379550515_Screenshot_20221125_133156_Spika3](https://user-images.githubusercontent.com/50554253/203987156-6d992778-d2df-4b3a-936c-40372a06accf.jpg)

