### PR TITLE
Copy message functionality

### DIFF
--- a/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/ChatMessagesFragment.kt
@@ -1,7 +1,10 @@
 package com.clover.studio.exampleapp.ui.main.chat
 
 import android.Manifest
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.ContentResolver
+import android.content.Context.CLIPBOARD_SERVICE
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.media.MediaMetadataRetriever
@@ -201,7 +204,12 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
         bindingSetup.tvChatName.text = userName
         Glide.with(this)
             .load(avatarFileId.let { Tools.getFilePathUrl(it) })
-            .placeholder(AppCompatResources.getDrawable(requireContext(), R.drawable.img_user_placeholder))
+            .placeholder(
+                AppCompatResources.getDrawable(
+                    requireContext(),
+                    R.drawable.img_user_placeholder
+                )
+            )
             .into(bindingSetup.ivUserImage)
     }
 
@@ -663,6 +671,14 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
             bottomSheetMessageActions.state = BottomSheetBehavior.STATE_COLLAPSED
             getDetailsList(msg.message)
             bottomSheetDetailsAction.state = BottomSheetBehavior.STATE_EXPANDED
+        }
+
+        bindingSetup.messageActions.tvCopy.setOnClickListener {
+            val clipboard = requireContext().getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+            val clip: ClipData = ClipData.newPlainText("", msg.message.body?.text.toString())
+            clipboard.setPrimaryClip(clip)
+            bottomSheetMessageActions.state = BottomSheetBehavior.STATE_COLLAPSED
+            Toast.makeText(requireContext(), getString(R.string.text_copied), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/res/layout/message_actions.xml
+++ b/app/src/main/res/layout/message_actions.xml
@@ -78,7 +78,7 @@
             android:fontFamily="@font/montserrat"
             android:text="@string/copy"
             android:textSize="@dimen/sixteen_sp_text"
-            android:visibility="gone"
+            android:visibility="visible"
             app:drawableLeftCompat="@drawable/img_copy"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,7 @@
     <string name="delete_for_me">Delete for me</string>
     <string name="save">Save</string>
     <string name="edited">edited</string>
+    <string name="text_copied">Text copied</string>
 
     <string name="enter_title">Enter title</string>
     <string name="enter_description">Enter description</string>


### PR DESCRIPTION
# Description

Implemented copy message functionality. The user can now hold on to the message for a long time and when the bottom sheet appears, select the copy option for copying.

![copy](https://user-images.githubusercontent.com/46626092/215446870-8e70136e-08d6-40a3-baaa-2f874556f255.jpeg)


Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules