### PR TITLE
Remove Send when Media Container is Empty

### DIFF
--- a/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/ChatMessagesFragment.kt
+++ b/app/src/main/java/com/clover/studio/exampleapp/ui/main/chat/ChatMessagesFragment.kt
@@ -1723,6 +1723,9 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
                 Timber.d("Files selected 2: $filesSelected")
                 bindingSetup.llImagesContainer.removeView(imageSelected)
                 bindingSetup.ivAdd.rotation = ROTATION_OFF
+                if (bindingSetup.llImagesContainer.childCount == 0) {
+                    hideSendButton()
+                }
             }
         })
         bindingSetup.llImagesContainer.addView(imageSelected)
@@ -1774,6 +1777,9 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
                 Timber.d("Media selected 2: $currentMediaLocation")
                 bindingSetup.llImagesContainer.removeView(imageSelected)
                 bindingSetup.ivAdd.rotation = ROTATION_OFF
+                if (bindingSetup.llImagesContainer.childCount == 0) {
+                    hideSendButton()
+                }
             }
         })
 
@@ -1823,6 +1829,9 @@ class ChatMessagesFragment : BaseFragment(), ChatOnBackPressed {
                 Timber.d("Media selected 2: $currentMediaLocation")
                 bindingSetup.llImagesContainer.removeView(imageSelected)
                 bindingSetup.ivAdd.rotation = ROTATION_OFF
+                if (bindingSetup.llImagesContainer.childCount == 0) {
+                    hideSendButton()
+                }
             }
         })
         val thumbnail =


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant
motivation and context. List any dependencies that are required for this change.

Fixes # Removed send button when no items are left in the media container. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration. All testing was done
manually by following, plainly, functionality requirements. If there are some special edge cases or
special ways that things need to be tested they will be mentioned below.

Dev testing

**Test Configuration**:

* Firmware version: G980FXXSFFVHA
* Hardware: SAMSUNG Galaxy S20
* SDK: Android 13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
