### PR TITLE
Reply max lines

### DIFF
--- a/app/src/main/res/layout/item_message_me.xml
+++ b/app/src/main/res/layout/item_message_me.xml
@@ -112,7 +112,7 @@
                     android:ellipsize="end"
                     android:fontFamily="@font/montserrat"
                     android:maxEms="20"
-                    android:maxLines="6"
+                    android:maxLines="3"
                     android:text="@string/some_message"
                     android:textColorLink="@color/link_primary_color"
                     android:textSize="@dimen/eleven_sp_text"

--- a/app/src/main/res/layout/item_message_other.xml
+++ b/app/src/main/res/layout/item_message_other.xml
@@ -112,7 +112,7 @@
                     android:ellipsize="end"
                     android:fontFamily="@font/montserrat"
                     android:maxEms="15"
-                    android:maxLines="6"
+                    android:maxLines="3"
                     android:text="@string/some_message"
                     android:textColorLink="@color/link_primary_color"
                     android:textSize="@dimen/eleven_sp_text"

--- a/app/src/main/res/layout/reply_action.xml
+++ b/app/src/main/res/layout/reply_action.xml
@@ -45,7 +45,7 @@
             android:ellipsize="end"
             android:fontFamily="@font/montserrat"
             android:gravity="center|start"
-            android:maxLines="3"
+            android:maxLines="1"
             android:text="@string/some_message"
             android:textColorLink="@color/link_primary_color"
             android:textSize="@dimen/eleven_sp_text"


### PR DESCRIPTION
# Description

Updated reply max lines design:
- when the reply is opened in the bottom sheet, only one message line is displayed
- when a reply to a message is made in the chat, three lines of the message are displayed
![4](https://user-images.githubusercontent.com/46626092/227867859-ce8c45e4-e0fd-4bc1-bc89-a3ee4a04831b.png)
![3](https://user-images.githubusercontent.com/46626092/227867864-162b9b97-4d45-4309-9718-b492b48a7c71.png)


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules