### PR TITLE
Dark theme - country search input color fix

### DIFF
--- a/app/src/main/res/layout/fragment_country_picker.xml
+++ b/app/src/main/res/layout/fragment_country_picker.xml
@@ -23,6 +23,7 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/twenty_dp_margin"
         android:background="@drawable/bg_search_field"
+        android:backgroundTint="@color/message_other"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tv_cancel"


### PR DESCRIPTION
# Description

Fixed color for country search input.

![1](https://user-images.githubusercontent.com/46626092/230013374-e126e3e9-d03f-4131-a58f-8c86e09152e7.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules