### PR TITLE
Dark theme - messages states

### DIFF
--- a/app/src/main/res/drawable/img_done.xml
+++ b/app/src/main/res/drawable/img_done.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="16">
   <path
       android:pathData="M14.8268,3.7266L7.7734,10.7799L4.9868,7.9999L4.0468,8.9399L7.7734,12.6666L15.7734,4.6666L14.8268,3.7266ZM12.0001,4.6666L11.0601,3.7266L6.8334,7.9532L7.7734,8.8932L12.0001,4.6666ZM4.0001,12.6666L0.2734,8.9399L1.2201,7.9999L4.9401,11.7266L4.0001,12.6666Z"
-      android:fillColor="#5F6368"
+      android:fillColor="@color/messages_states"
       android:fillType="evenOdd"/>
 </vector>

--- a/app/src/main/res/drawable/img_edited_gray.xml
+++ b/app/src/main/res/drawable/img_edited_gray.xml
@@ -5,6 +5,6 @@
     android:viewportHeight="13">
   <path
       android:pathData="M10.847,1.22L11.787,2.16C12.307,2.68 12.307,3.52 11.78,4.047L2.827,13H0V10.173L8.96,1.22C9.48,0.7 10.327,0.7 10.847,1.22ZM1.333,11.667H2.273L8.953,4.98L8.013,4.04L1.333,10.727V11.667Z"
-      android:fillColor="@color/icons"
+      android:fillColor="@color/messages_states"
       android:fillType="evenOdd"/>
 </vector>

--- a/app/src/main/res/drawable/img_no_edit.xml
+++ b/app/src/main/res/drawable/img_no_edit.xml
@@ -7,6 +7,6 @@
       android:strokeWidth="1"
       android:pathData="M0.5,0.5L11.5,0.5"
       android:fillColor="#00000000"
-      android:strokeColor="#141414"
+      android:strokeColor="@color/messages_states"
       android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/img_sent.xml
+++ b/app/src/main/res/drawable/img_sent.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="16">
   <path
       android:pathData="M5.9999,10.8001L3.1999,8.0001L2.2666,8.9334L5.9999,12.6667L13.9999,4.6667L13.0666,3.7334L5.9999,10.8001Z"
-      android:fillColor="@color/icons"/>
+      android:fillColor="@color/messages_states"/>
 </vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -25,6 +25,7 @@
     <color name="error_background">#FFECEC</color>
     <color name="guideline">#E6E6E6</color>
     <color name="gray_transparent">#66F2F2F2</color>
+    <color name="messages_states">#5F6368</color>
 
     <!--Application colors: light - dark themes-->
     <!--Main color: white - black-->


### PR DESCRIPTION
# Description

Fixed dark theme colors for message states (sent, edited).

![2](https://user-images.githubusercontent.com/46626092/230588442-fbb3f661-83b8-426c-924d-c553fa19b7fd.png)
![3](https://user-images.githubusercontent.com/46626092/230588447-eb57c9ba-e2e7-4797-9e0f-98185549f248.png)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Dev testing.

**Test Configuration**:

* Firmware version: G930FXXS7ETA1
* Hardware: Samsung galaxy s7
* SDK: Android 8, Oreo

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
